### PR TITLE
Add libpython2.7 package for Xenial

### DIFF
--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -10,7 +10,7 @@
         'remote_collector': False
     },
     'Debian': {
-        'pkgs': ['collectd-core', 'snmp', 'python-yaml'],
+        'pkgs': ['collectd-core', 'snmp', 'python-yaml', 'libpython2.7'],
         'service': 'collectd',
         'config_file': '/etc/collectd/collectd.conf',
         'config_dir': '/etc/collectd/conf.d',


### PR DESCRIPTION
This dependency isn't installed by default on Xenial.
