### PR TITLE
Use Node instead of URL in plugin http_write

### DIFF
--- a/collectd/files/backend/http.conf
+++ b/collectd/files/backend/http.conf
@@ -4,8 +4,9 @@
 </LoadPlugin>
 
 <Plugin write_http>
-  <URL "http://{{ backend.host }}:{{ backend.port }}">
+  <Node "{{ backend_name }}">
+    URL "http://{{ backend.host }}:{{ backend.port }}"
     Format "{{ backend.get('format', 'json')|upper }}"
     StoreRates {{ backend.get('store_rates', True)|lower }}
-  </URL>
+  </Node>
 </Plugin>


### PR DESCRIPTION
Configuring an http_write plugin with a `<URL>` block is deprecated. `<Node>` is to be used instead.

This commit fixes this, removing this message in the collectd logs:

```
    write_http plugin: Legacy <URL> block found. Please use <Node> instead.
```
