### PR TITLE
Revert "Use Node instead of URL in plugin http_write"

### DIFF
--- a/collectd/files/backend/http.conf
+++ b/collectd/files/backend/http.conf
@@ -4,9 +4,8 @@
 </LoadPlugin>
 
 <Plugin write_http>
-  <Node "{{ backend_name }}">
-    URL "http://{{ backend.host }}:{{ backend.port }}"
+  <URL "http://{{ backend.host }}:{{ backend.port }}">
     Format "{{ backend.get('format', 'json')|upper }}"
     StoreRates {{ backend.get('store_rates', True)|lower }}
-  </Node>
+  </URL>
 </Plugin>


### PR DESCRIPTION
This reverts tcpcloud/salt-formula-collectd#6 because it does not work with collectd 5.4.0, which is the version we use on Trusty.
