### PR TITLE
Install the python-simplejson package

### DIFF
--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -10,7 +10,7 @@
         'remote_collector': False
     },
     'Debian': {
-        'pkgs': ['collectd-core', 'snmp', 'python-yaml'],
+        'pkgs': ['collectd-core', 'snmp', 'python-yaml', 'python-simplejson'],
         'service': 'collectd',
         'config_file': '/etc/collectd/collectd.conf',
         'config_dir': '/etc/collectd/conf.d',


### PR DESCRIPTION
This package is required to use collectd Python plugins.
