### PR TITLE
Fix configuration of the local endpoint checks

### DIFF
--- a/collectd/meta/collectd.yml
+++ b/collectd/meta/collectd.yml
@@ -40,7 +40,6 @@ local_plugin:
         - 1.3.6.1.2.1.31.1.1.1.11
     host: {{ pillar.external.network_device|yaml }}
   {%- endif %}
-remote_plugin:
   collectd_check_local_endpoint:
     plugin: python
     execution: remote


### PR DESCRIPTION
As the name tells it, the checks are executed locally.