### PR TITLE
Fix Python plugins launching external processes

### DIFF
--- a/collectd/files/plugin/collectd_apache_check.py
+++ b/collectd/files/plugin/collectd_apache_check.py
@@ -50,10 +50,6 @@ class ApacheCheckPlugin(base.Base):
 plugin = ApacheCheckPlugin(collectd)
 
 
-def init_callback():
-    plugin.restore_sigchld()
-
-
 def config_callback(conf):
     plugin.config_callback(conf)
 
@@ -61,6 +57,5 @@ def config_callback(conf):
 def read_callback():
     plugin.read_callback()
 
-collectd.register_init(init_callback)
 collectd.register_config(config_callback)
 collectd.register_read(read_callback)

--- a/collectd/files/plugin/collectd_libvirt_check.py
+++ b/collectd/files/plugin/collectd_libvirt_check.py
@@ -49,10 +49,6 @@ class LibvirtCheckPlugin(base.Base):
 plugin = LibvirtCheckPlugin(collectd)
 
 
-def init_callback():
-    plugin.restore_sigchld()
-
-
 def config_callback(conf):
     plugin.config_callback(conf)
 
@@ -60,6 +56,5 @@ def config_callback(conf):
 def read_callback():
     plugin.read_callback()
 
-collectd.register_init(init_callback)
 collectd.register_config(config_callback)
 collectd.register_read(read_callback)

--- a/collectd/files/plugin/collectd_memcached_check.py
+++ b/collectd/files/plugin/collectd_memcached_check.py
@@ -60,10 +60,6 @@ class MemcachedCheckPlugin(base.Base):
 plugin = MemcachedCheckPlugin(collectd)
 
 
-def init_callback():
-    plugin.restore_sigchld()
-
-
 def config_callback(conf):
     plugin.config_callback(conf)
 
@@ -71,6 +67,5 @@ def config_callback(conf):
 def read_callback():
     plugin.read_callback()
 
-collectd.register_init(init_callback)
 collectd.register_config(config_callback)
 collectd.register_read(read_callback)

--- a/collectd/files/plugin/collectd_mysql_check.py
+++ b/collectd/files/plugin/collectd_mysql_check.py
@@ -103,10 +103,6 @@ class MySQLCheckPlugin(base.Base):
 plugin = MySQLCheckPlugin(collectd)
 
 
-def init_callback():
-    plugin.restore_sigchld()
-
-
 def config_callback(conf):
     plugin.config_callback(conf)
 
@@ -114,6 +110,5 @@ def config_callback(conf):
 def read_callback():
     plugin.read_callback()
 
-collectd.register_init(init_callback)
 collectd.register_config(config_callback)
 collectd.register_read(read_callback)

--- a/collectd/files/plugin/collectd_vrrp.py
+++ b/collectd/files/plugin/collectd_vrrp.py
@@ -73,10 +73,6 @@ class VrrpPlugin(base.Base):
 plugin = VrrpPlugin(collectd)
 
 
-def init_callback():
-    plugin.restore_sigchld()
-
-
 def config_callback(conf):
     plugin.config_callback(conf)
 
@@ -84,6 +80,5 @@ def config_callback(conf):
 def read_callback():
     plugin.read_callback()
 
-collectd.register_init(init_callback)
 collectd.register_config(config_callback)
 collectd.register_read(read_callback)

--- a/collectd/files/plugin/elasticsearch_cluster.py
+++ b/collectd/files/plugin/elasticsearch_cluster.py
@@ -109,10 +109,6 @@ class ElasticsearchClusterHealthPlugin(base.Base):
 plugin = ElasticsearchClusterHealthPlugin(collectd, 'elasticsearch')
 
 
-def init_callback():
-    plugin.restore_sigchld()
-
-
 def config_callback(conf):
     plugin.config_callback(conf)
 
@@ -120,6 +116,5 @@ def config_callback(conf):
 def read_callback():
     plugin.read_callback()
 
-collectd.register_init(init_callback)
 collectd.register_config(config_callback)
 collectd.register_read(read_callback)

--- a/collectd/files/plugin/haproxy.py
+++ b/collectd/files/plugin/haproxy.py
@@ -291,10 +291,6 @@ class HAProxyPlugin(base.Base):
 plugin = HAProxyPlugin(collectd)
 
 
-def init_callback():
-    plugin.restore_sigchld()
-
-
 def config_callback(conf):
     plugin.config_callback(conf)
 
@@ -302,6 +298,5 @@ def config_callback(conf):
 def read_callback():
     plugin.read_callback()
 
-collectd.register_init(init_callback)
 collectd.register_config(config_callback)
 collectd.register_read(read_callback)

--- a/collectd/files/plugin/influxdb.py
+++ b/collectd/files/plugin/influxdb.py
@@ -129,10 +129,6 @@ class InfluxDBClusterPlugin(base.Base):
 plugin = InfluxDBClusterPlugin(collectd)
 
 
-def init_callback():
-    plugin.restore_sigchld()
-
-
 def config_callback(conf):
     plugin.config_callback(conf)
 
@@ -140,6 +136,5 @@ def config_callback(conf):
 def read_callback():
     plugin.read_callback()
 
-collectd.register_init(init_callback)
 collectd.register_config(config_callback)
 collectd.register_read(read_callback)


### PR DESCRIPTION
Without this change, Python plugins running external processes never
get the return code. See the collectd code [1] for the details.

[1] https://github.com/collectd/collectd/blob/master/contrib/python/getsigchld.py