### PR TITLE
Split the Elasticsearch plugin

### DIFF
--- a/collectd/files/plugin/collectd_elasticsearch_base.py
+++ b/collectd/files/plugin/collectd_elasticsearch_base.py
@@ -1,0 +1,68 @@
+#!/usr/bin/python
+# Copyright 2016 Mirantis, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import requests
+
+import collectd_base as base
+
+
+class ElasticsearchBase(base.Base):
+    def __init__(self, *args, **kwargs):
+        super(ElasticsearchBase, self).__init__(*args, **kwargs)
+        self.protocol = 'http'
+        self.address = '127.0.0.1'
+        self.port = 9200
+        self.url = None
+        self.session = requests.Session()
+        self.session.mount(
+            'http://',
+            requests.adapters.HTTPAdapter(max_retries=self.max_retries)
+        )
+        self.session.mount(
+            'https://',
+            requests.adapters.HTTPAdapter(max_retries=self.max_retries)
+        )
+
+    def config_callback(self, conf):
+        super(ElasticsearchBase, self).config_callback(conf)
+
+        for node in conf.children:
+            if node.key == 'Address':
+                self.address = node.values[0]
+            if node.key == 'Port':
+                self.port = node.values[0]
+            if node.key == 'Protocol':
+                self.protocol = node.values[0]
+
+        self.url = "{protocol}://{address}:{port}/".format(
+            **{
+                'protocol': self.protocol,
+                'address': self.address,
+                'port': int(self.port),
+            })
+
+    def query_api(self, resource):
+        url = "{}{}".format(self.url, resource)
+        try:
+            r = self.session.get(url, timeout=self.timeout)
+        except Exception as e:
+            msg = "Got exception for '{}': {}".format(url, e)
+            raise base.CheckException(msg)
+
+        if r.status_code != 200:
+            msg = "{} responded with code {}".format(url, r.status_code)
+            raise base.CheckException(msg)
+
+        return r.json()

--- a/collectd/files/plugin/collectd_elasticsearch_cluster.py
+++ b/collectd/files/plugin/collectd_elasticsearch_cluster.py
@@ -14,9 +14,8 @@
 # limitations under the License.
 
 import collectd
-import requests
 
-import collectd_base as base
+import collectd_elasticsearch_base as base
 
 NAME = 'elasticsearch_cluster'
 HEALTH_MAP = {
@@ -29,63 +28,12 @@ METRICS = ['number_of_nodes', 'active_primary_shards', 'active_primary_shards',
            'number_of_pending_tasks', 'initializing_shards']
 
 
-class ElasticsearchClusterHealthPlugin(base.Base):
+class ElasticsearchClusterHealthPlugin(base.ElasticsearchBase):
     def __init__(self, *args, **kwargs):
         super(ElasticsearchClusterHealthPlugin, self).__init__(*args, **kwargs)
         self.plugin = NAME
-        self.address = '127.0.0.1'
-        self.port = 9200
-        self._node_id = None
-        self.session = requests.Session()
-        self.url = None
-        self.session.mount(
-            'http://',
-            requests.adapters.HTTPAdapter(max_retries=self.max_retries)
-        )
-
-    def config_callback(self, conf):
-        super(ElasticsearchClusterHealthPlugin, self).config_callback(conf)
-
-        for node in conf.children:
-            if node.key == 'Address':
-                self.address = node.values[0]
-            if node.key == 'Port':
-                self.port = node.values[0]
-
-        self.url = "http://{address}:{port}/".format(
-            **{
-                'address': self.address,
-                'port': int(self.port),
-            })
-
-    def query_api(self, resource):
-        url = "{}{}".format(self.url, resource)
-        try:
-            r = self.session.get(url)
-        except Exception as e:
-            msg = "Got exception for '{}': {}".format(url, e)
-            raise base.CheckException(msg)
-
-        if r.status_code != 200:
-            msg = "{} responded with code {}".format(url, r.status_code)
-            raise base.CheckException(msg)
-
-        return r.json()
-
-    @property
-    def node_id(self):
-        if self._node_id is None:
-            local_node = self.query_api('_nodes/_local')
-            self._node_id = local_node.get('nodes', {}).keys()[0]
-
-        return self._node_id
 
     def itermetrics(self):
-        # Collect cluster metrics only from the elected master
-        master_node = self.query_api('_cluster/state/master_node')
-        if master_node.get('master_node', '') != self.node_id:
-            return
-
         data = self.query_api('_cluster/health')
         self.logger.debug("Got response from Elasticsearch: '%s'" % data)
 
@@ -106,7 +54,7 @@ class ElasticsearchClusterHealthPlugin(base.Base):
                 'values': value
             }
 
-plugin = ElasticsearchClusterHealthPlugin(collectd, 'elasticsearch')
+plugin = ElasticsearchClusterHealthPlugin(collectd)
 
 
 def config_callback(conf):

--- a/collectd/files/plugin/collectd_elasticsearch_node.py
+++ b/collectd/files/plugin/collectd_elasticsearch_node.py
@@ -1,0 +1,55 @@
+#!/usr/bin/python
+# Copyright 2016 Mirantis, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collectd
+
+import collectd_elasticsearch_base as base
+
+NAME = 'elasticsearch'
+
+
+class ElasticsearchNodePlugin(base.ElasticsearchBase):
+    def __init__(self, *args, **kwargs):
+        super(ElasticsearchNodePlugin, self).__init__(*args, **kwargs)
+        self.plugin = NAME
+
+    def itermetrics(self):
+        stats = self.query_api('_nodes/_local/stats').get(
+            'nodes', {}).values()[0]
+        yield {
+            'type_instance': 'documents',
+            'values': stats['indices']['docs']['count']
+        }
+        yield {
+            'type_instance': 'documents_deleted',
+            'values': stats['indices']['docs']['deleted']
+        }
+        # TODO: collectd more metrics
+        # See https://www.elastic.co/guide/en/elasticsearch/guide/current/
+        # _monitoring_individual_nodes.html
+
+
+plugin = ElasticsearchNodePlugin(collectd)
+
+
+def config_callback(conf):
+    plugin.config_callback(conf)
+
+
+def read_callback():
+    plugin.read_callback()
+
+collectd.register_config(config_callback)
+collectd.register_read(read_callback)


### PR DESCRIPTION
This change separates the Elasticsearch plugin into 2 different plugins:

- one responsible for collecting the node metrics, to be deployed on
  the Elasticsearch node(s).
- one responsible for collecting the cluster metrics, to be deployed on
  the remote collector node.