### PR TITLE
Add cinder|neutron|nova_services_percent metrics

### DIFF
--- a/collectd/files/plugin/openstack_cinder.py
+++ b/collectd/files/plugin/openstack_cinder.py
@@ -55,7 +55,14 @@ class CinderStatsPlugin(openstack.CollectdPlugin):
                                  'state': state})
 
         for service in aggregated_workers:
+            totalw = sum(aggregated_workers[service].values())
+
             for state in self.states:
+                prct = (100.0 * aggregated_workers[service][state]) / totalw
+                self.dispatch_value('cinder_services_percent', '',
+                                    prct,
+                                    {'state': state, 'service': service})
+
                 self.dispatch_value('cinder_services', '',
                                     aggregated_workers[service][state],
                                     {'state': state, 'service': service})

--- a/collectd/files/plugin/openstack_neutron.py
+++ b/collectd/files/plugin/openstack_neutron.py
@@ -85,7 +85,14 @@ class NeutronStatsPlugin(openstack.CollectdPlugin):
                                  'state': state})
 
         for service in aggregated_agents:
+            totala = sum(aggregated_agents[service].values())
+
             for state in self.states:
+                prct = (100.0 * aggregated_agents[service][state]) / totala
+                self.dispatch_value('neutron_agents_percent',
+                                    prct,
+                                    {'service': service, 'state': state})
+
                 self.dispatch_value('neutron_agents',
                                     aggregated_agents[service][state],
                                     {'service': service, 'state': state})

--- a/collectd/files/plugin/openstack_nova.py
+++ b/collectd/files/plugin/openstack_nova.py
@@ -53,7 +53,14 @@ class NovaStatsPlugin(openstack.CollectdPlugin):
                                  'state': state})
 
         for service in aggregated_workers:
+            totalw = sum(aggregated_workers[service].values())
+
             for state in self.states:
+                prct = (100.0 * aggregated_workers[service][state]) / totalw
+                self.dispatch_value('nova_services_percent', '',
+                                    prct,
+                                    {'state': state, 'service': service})
+
                 self.dispatch_value('nova_services', '',
                                     aggregated_workers[service][state],
                                     {'state': state, 'service': service})


### PR DESCRIPTION
This adds support for the cinder_services_percent, neutron_services_percent, and nova_services_percent metrics.

Corresponding commit to fuel-plugin-lma-collector: https://github.com/openstack/fuel-plugin-lma-collector/commit/506196dcefcb20f801032656c0884de9f034769c