### PR TITLE
Fix openstack_check_api for unknown service

### DIFF
--- a/collectd/files/plugin/check_openstack_api.py
+++ b/collectd/files/plugin/check_openstack_api.py
@@ -69,6 +69,7 @@ class APICheckPlugin(openstack.CollectdPlugin):
                 self.logger.notice(
                     "No check found for service '%s', skipping it" % name)
                 status = self.UNKNOWN
+                check = {}
             else:
                 check = self.CHECK_MAP[name]
                 url = self._service_url(service['url'], check['path'])


### PR DESCRIPTION
fail to get metrics: local variable 'check' referenced before assignment: Traceback (most recent call last):
  File "/usr/lib/collectd-python/collectd_openstack.py", line 287, in read_callback
    self.collect()
  File "/usr/lib/collectd-python/check_openstack_api.py", line 97, in collect
    for item in self.check_api():
  File "/usr/lib/collectd-python/check_openstack_api.py", line 91, in check_api
    'service': check.get('name', name),
UnboundLocalError: local variable 'check' referenced before assignment