### PR TITLE
Fix calls to the execute() method

### DIFF
--- a/collectd/files/plugin/collectd_base.py
+++ b/collectd/files/plugin/collectd_base.py
@@ -165,15 +165,12 @@ class Base(object):
             non-zero status code (default=True).
 
         Returns:
-            A tuple containing the standard output and error strings if the
-            program execution has been successful.
+            A tuple containing the return code, the standard output and the
+            standard error if the program has been executed.
 
-            ("foobar\n", "")
+            (0, "foobar\n", "")
 
-            (None, "stderr of the command") if the command returned a
-            non-zero status code.
-
-            (None, None) if the command couldn't be executed at all.
+            (-1, None, None) if the program couldn't be executed at all.
         """
         start_time = time.time()
         try:
@@ -189,24 +186,19 @@ class Base(object):
         except Exception as e:
             self.logger.error("Cannot execute command '%s': %s : %s" %
                               (cmd, str(e), traceback.format_exc()))
-            return (None, None)
+            return (-1, None, None)
 
         returncode = proc.returncode
 
-        if returncode != 0:
-            if log_error:
-                self.logger.error("Command '%s' failed (return code %d): %s" %
-                                  (cmd, returncode, stderr))
-            return (None, stderr)
+        if returncode != 0 and log_error:
+            self.logger.error("Command '%s' failed (return code %d): %s" %
+                              (cmd, returncode, stderr))
         if self.debug:
             elapsedtime = time.time() - start_time
             self.logger.info("Command '%s' returned %s in %0.3fs" %
                              (cmd, returncode, elapsedtime))
 
-        if not stdout and self.debug:
-            self.logger.info("Command '%s' returned no output!", cmd)
-
-        return (stdout, stderr)
+        return (returncode, stdout, stderr)
 
     def execute_to_json(self, *args, **kwargs):
         """Executes a program and decodes the output as a JSON string.
@@ -217,12 +209,12 @@ class Base(object):
             A Python object or
             None if the execution of the program or JSON decoding fails.
         """
-        outputs = self.execute(*args, **kwargs)
-        if outputs:
+        (retcode, out, err) = self.execute(*args, **kwargs)
+        if retcode == 0:
             try:
-                return json.loads(outputs[0])
+                return json.loads(out)
             except ValueError as e:
-                self.logger.error("{}: document: '{}'".format(e, outputs[0]))
+                self.logger.error("{}: document: '{}'".format(e, out))
 
     @staticmethod
     def restore_sigchld():

--- a/collectd/files/plugin/collectd_glusterfs.py
+++ b/collectd/files/plugin/collectd_glusterfs.py
@@ -59,9 +59,9 @@ class GlusterfsPlugin(base.Base):
 
     def itermetrics(self):
         # Collect peers' metrics
-        out, err = self.execute([GLUSTER_BINARY, 'peer', 'status'],
-                                shell=False)
-        if not out:
+        retcode, out, err = self.execute([GLUSTER_BINARY, 'peer', 'status'],
+                                         shell=False)
+        if retcode != 0:
             raise base.CheckException("Failed to execute 'gluster peer'")
 
         total = 0
@@ -107,8 +107,8 @@ class GlusterfsPlugin(base.Base):
 
         # Collect volumes' metrics
         cmd = [GLUSTER_BINARY, 'volume', 'status', 'all', 'detail']
-        out, err = self.execute(cmd, shell=False, log_error=False)
-        if not out:
+        retcode, out, err = self.execute(cmd, shell=False, log_error=False)
+        if retcode != 0:
             if err and vol_status_transaction_in_progress_re.match(err):
                 # "transaction already in progress" error, we assume volumes
                 # metrics are being collected on another glusterfs node, and

--- a/collectd/files/plugin/collectd_pacemaker.py
+++ b/collectd/files/plugin/collectd_pacemaker.py
@@ -73,9 +73,9 @@ class CrmMonitorPlugin(base.Base):
                 return 1
             return 0
 
-        out, err = self.execute([self.crm_mon_binary, '--as-xml', '-r', '-f'],
-                                shell=False)
-        if not out:
+        retcode, out, err = self.execute(
+            [self.crm_mon_binary, '--as-xml', '-r', '-f'], shell=False)
+        if retcode != 0:
             raise base.CheckException(
                 "Failed to execute crm_mon '{}'".format(err))
 


### PR DESCRIPTION
During the porting of StackLight to the MK platform, the value returned
by the execute() method has changes but not all collectd plugins have
been updated. This commit fixes the problem.