### PR TITLE
Sort the collectd.yml grain fragments before merge

### DIFF
--- a/collectd/client.sls
+++ b/collectd/client.sls
@@ -14,7 +14,8 @@ include:
 
 {%- set service_grains = {'collectd': {'remote_plugin': {}, 'local_plugin': {}}} %}
 
-{%- for service_name, service in pillar.items() %}
+{%- for service_name in salt['pillar.ls']()|sort %}
+{%- set service = salt['pillar.items'](service_name)[service_name] %}
 {%- if service.get('_support', {}).get('collectd', {}).get('enabled', False) %}
 
 {%- set grains_fragment_file = service_name+'/meta/collectd.yml' %}


### PR DESCRIPTION
Let's merge the `meta/collectd.yml` grain fragment files in a
determinstic order by sorting the service names first.

This will make it easier to override values if, for example, I do not
want to use the default CPU plugin for collectd.