### PR TITLE
change cmd.run to cmd.shell

### DIFF
--- a/collectd/files/default_collectd
+++ b/collectd/files/default_collectd
@@ -14,7 +14,7 @@ MAXWAIT=30
 # default: 0
 ENABLE_COREFILES=0
 {%- set java_ld_library_path = '' %}
-{%- set java_lib = salt['cmd.run']('type java >/dev/null 2>&1 && find /usr/lib/jvm -name libjvm.so -type f') %}
+{%- set java_lib = salt['cmd.shell']('type java >/dev/null 2>&1 && find /usr/lib/jvm -name libjvm.so -type f') %}
 {%- if java_lib|length > 0 %}
   {%- set java_path = '/'.join(java_lib.split('/')[:-1]) %}
   {%- set java_ld_library_path = 'export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:' ~ java_path %}


### PR DESCRIPTION
this cmd.run not work in salt 2017.7.0
warning from salt 2016.3.6.:
[WARNING ] /usr/lib/python2.7/dist-packages/salt/utils/templates.py:73: DeprecationWarning: Starting in 2015.5, cmd.run uses python_shell=False by default, which doesn't support shellisms (pipes, env variables, etc). cmd.run is currently  aliased to cmd.shell to prevent breakage. Please switch to cmd.shell or set python_shell=True to avoid breakage in the future, when this aliasing is removed.